### PR TITLE
Solve the overflow in calculating color distance

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def get_segmented_image(sigma, neighbor, K, min_comp_size, input_file, output_fi
 
     # Gaussian Filter
     smooth = image_file.filter(ImageFilter.GaussianBlur(sigma))
-    smooth = np.array(smooth)
+    smooth = np.array(smooth).astype(int)
     
     logger.info("Creating graph...")
     graph_edges = build_graph(smooth, size[1], size[0], diff, neighbor==8)


### PR DESCRIPTION
Convert directly from RGB image to numpy array. The numpy array type is uint8. At this time, when calculating the distance between colors, overflow will occur. So I changed the type to int during conversion.